### PR TITLE
Update workflow configuration

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -58,4 +58,4 @@ jobs:
           commit_email: ${{ secrets.AUR_EMAIL }}
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           commit_message: Update AUR package
-          ssh_keyscan_types: rsa,dsa,ecdsa,ed25519
+          ssh_keyscan_types: rsa,ecdsa,ed25519

--- a/src/t2sz.c
+++ b/src/t2sz.c
@@ -639,8 +639,8 @@ static void compressStdinRaw(Context *ctx){
                 }
             }
 
-            if (n == 0) {
-                if (ferror(stdin)) {
+            if(n == 0){
+                if(ferror(stdin)){
                     fprintf(stderr, "ERROR: Read error on stdin\n");
                     free(inBuf);
                     exit(EXIT_FAILURE);


### PR DESCRIPTION
This pull request makes a minor adjustment to the SSH keyscan types used in the AUR workflow configuration. The change removes support for the `dsa` key type, for compatibility reasons with modern systems that dropped dsa.

* [`.github/workflows/aur.yml`](diffhunk://#diff-3b2384f4b4ce6387abb5b8663fdf8612c2070e506a4c088bbe293e6688003699L61-R61): Removed `dsa` from the list of `ssh_keyscan_types` in the AUR job configuration.