### PR TITLE
Add Windows support and update to version 1.2.3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,26 @@ jobs:
         run: |
           gh release upload "${GITHUB_REF##*/}" ${{runner.workspace}}/build/*.deb
 
+  build-windows:
+    needs: [test, test-asan]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cross-compile Windows (Release, amd64 + arm64)
+        run: bash windows/win-cross-build.sh both
+
+      - name: Cross-compile + test Windows (Debug, amd64 via Wine)
+        run: bash windows/win-cross-test.sh
+
+      - name: Upload Windows executables
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cp build-windows-amd64-release/t2sz.exe t2sz-amd64.exe
+          cp build-windows-arm64-release/t2sz.exe t2sz-arm64.exe
+          gh release upload "${GITHUB_REF##*/}" t2sz-amd64.exe t2sz-arm64.exe
+
   homebrew:
     needs: [build]
     runs-on: ubuntu-24.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,3 +63,11 @@ jobs:
         id: create-deb-package
         working-directory: ${{runner.workspace}}/build
         run: cpack
+
+  build-windows:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cross-compile + test Windows (amd64 via Wine)
+        run: bash windows/win-cross-test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 .idea
 build
-build_asan/
-build_cov/
-build_fuzz/
+build_*/
+build-windows-*/
+out/
 tests/blobs/
 tests/coverage/
-tests/cmake-build-*
-cmake-build-*
+tests/cmake-build-*/
+cmake-build-*/

--- a/APKBUILD
+++ b/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Marco Martinelli <marco+t2sz@13byte.com>
 # Maintainer: Marco Martinelli <marco+t2sz@13byte.com>
 pkgname=t2sz
-pkgver=1.2.2
+pkgver=1.2.3
 pkgrel=0
 pkgdesc="t2sz compresses a file into a seekable zstd with special handling for tar archives."
 url="https://github.com/martinellimarco/t2sz"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(t2sz VERSION 1.2.2 LANGUAGES C)
+project(t2sz VERSION 1.2.3 LANGUAGES C)
 
 add_definitions(-DVERSION="${PROJECT_VERSION}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ target_include_directories(t2sz PRIVATE ${ZSTD_INC})
 target_link_libraries(t2sz ${ZSTD_LIB} m)
 
 if (CMAKE_BUILD_TYPE STREQUAL Release)
-    add_custom_command(TARGET t2sz POST_BUILD COMMAND ${CMAKE_STRIP} t2sz)
+    add_custom_command(TARGET t2sz POST_BUILD COMMAND ${CMAKE_STRIP} $<TARGET_FILE:t2sz>)
 endif ()
 
 install(TARGETS t2sz)

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 #Maintainer: Marco Martinelli <marco+t2sz@13byte.com>
 
 pkgname=t2sz
-pkgver=1.2.2
+pkgver=1.2.3
 pkgrel=1
 pkgdesc="It compresses a file into a seekable zstd. If the file is a tar archive it compresses each file in the archive into an independent frame, hence the name: tar 2 seekable zstd."
 arch=('i686' 'x86_64' 'armv7h' 'aarch64')

--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ then install it with
 sudo dpkg -i t2sz*.deb
 ```
 
+### Windows (cross-compilation)
+
+On macOS or Linux, cross-compile static Windows executables using Docker:
+
+```bash
+docker run --rm -v "$(pwd)":/src ubuntu:24.04 bash /src/windows/win-cross-build.sh both
+```
+
+This produces `t2sz.exe` for both amd64 and arm64 in `build-windows-{amd64,arm64}-release/`.
+Pre-built executables are also available on the [release page](https://github.com/martinellimarco/t2sz/releases/latest).
+
 ## Usage
 
 ```commandline

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ To take advantage of seeking see the following projects:
 
 ## Build
 
+### Linux
+
 You'll need `libzstd-dev`
 
 ```bash
@@ -64,6 +66,28 @@ then install it with
 
 ```bash
 sudo dpkg -i t2sz*.deb
+```
+
+### macOS
+
+You'll need `zstd` from Homebrew:
+
+```bash
+brew install zstd
+```
+
+```bash
+git clone https://github.com/martinellimarco/t2sz
+mkdir t2sz/build
+cd t2sz/build
+cmake .. -DCMAKE_BUILD_TYPE="Release"
+make
+```
+
+Install with
+
+```bash
+sudo make install
 ```
 
 ### Windows (cross-compilation)

--- a/TESTING.md
+++ b/TESTING.md
@@ -182,3 +182,74 @@ act --container-architecture linux/amd64 \
     -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:act-24.04 \
     push
 ```
+
+## Windows cross-compilation testing (Docker + Wine)
+
+The Windows executables are built with [llvm-mingw](https://github.com/mstorsjo/llvm-mingw)
+and tested under [Wine](https://www.winehq.org/) using the same CTest suite.
+Docker provides a reproducible Linux environment for both macOS and Linux hosts.
+
+Three scripts handle the cross-compilation workflow:
+
+| Script                       | Purpose                                                                  |
+|------------------------------|--------------------------------------------------------------------------|
+| `windows/win-cross-setup.sh` | Shared setup: installs llvm-mingw and downloads zstd source (idempotent) |
+| `windows/win-cross-build.sh` | Builds stripped Release executables for amd64, arm64, or both            |
+| `windows/win-cross-test.sh`  | Builds Debug with tests + LLVM coverage, runs CTest via Wine             |
+
+### Quick start
+
+```bash
+# Debug build + full CTest suite via Wine (amd64):
+docker run --rm --platform linux/amd64 -v "$(pwd)":/src ubuntu:24.04 bash /src/windows/win-cross-test.sh
+
+# Release build (both architectures):
+docker run --rm -v "$(pwd)":/src ubuntu:24.04 bash /src/windows/win-cross-build.sh both
+```
+
+The test script will:
+
+1. Install llvm-mingw and cross-compile zstd + t2sz for Windows
+2. Build with `-DBUILD_TESTS=ON` and LLVM coverage instrumentation
+3. Detect and verify Wine (graceful fallback to build-only if unavailable)
+4. Replace `.exe` files with bash wrappers that invoke Wine transparently
+5. Run all CTest tests through Wine
+6. Generate an LLVM coverage report
+
+### Build directories
+
+| Directory                     | Contents                                                      |
+|-------------------------------|---------------------------------------------------------------|
+| `build-windows-amd64-debug`   | Debug build with tests + coverage (amd64)                     |
+| `build-windows-arm64-debug`   | Debug build with tests (arm64, build-only — Wine unavailable) |
+| `build-windows-amd64-release` | Stripped Release binary (amd64)                               |
+| `build-windows-arm64-release` | Stripped Release binary (arm64)                               |
+
+### Wine wrapper trick
+
+CTest resolves `$<TARGET_FILE:t2sz>` to `t2sz.exe`.  On Linux, file extensions
+are ignored — the kernel checks the shebang.  The test script renames the real
+PE binary to `t2sz.real.exe` and creates a shell script at `t2sz.exe`:
+
+```bash
+#!/bin/bash
+WINEDEBUG=-all exec wine64 "/path/to/t2sz.real.exe" "$@"
+```
+
+This makes all 78 tests run through Wine with zero modifications to the test
+scripts or CMakeLists.txt.
+
+### Environment variables
+
+| Variable           | Default                    | Description                                                  |
+|--------------------|----------------------------|--------------------------------------------------------------|
+| `SRC_DIR`          | parent of script directory | Path to the t2sz source tree                                 |
+| `BUILD_BASE_DIR`   | `SRC_DIR`                  | Where `build-windows-*` directories are created              |
+| `CTEST_JOBS`       | `4`                        | CTest parallelism level (reduce if Wine processes cause OOM) |
+| `CTEST_EXTRA_ARGS` | *(empty)*                  | Extra flags passed to CTest (e.g. `--exclude-regex raw_1gb`) |
+
+### Known limitations
+
+- `raw_1gb` may timeout under Wine + coverage instrumentation (~10 min).
+- arm64 Windows executables cannot be tested (Wine on arm64 Linux hangs).
+- Coverage requires the amd64 platform (LLVM profiling runtime writes via Wine I/O).

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: t2sz
 base: core24
-version: '1.2.2'
+version: '1.2.3'
 summary: It compresses a file into a seekable .zstd file
 description: |
   It compresses a file into a seekable zstd splitting the file into multiple frames.

--- a/src/mman_compat.h
+++ b/src/mman_compat.h
@@ -1,0 +1,49 @@
+/**
+ * Minimal mmap/munmap compatibility layer for Windows (MinGW).
+ *
+ * Maps POSIX mmap(PROT_READ, MAP_PRIVATE) to the Windows
+ * CreateFileMapping + MapViewOfFile API.  Only the subset used
+ * by t2sz is implemented.
+ */
+#ifndef MMAN_COMPAT_H
+#define MMAN_COMPAT_H
+
+#ifdef _WIN32
+
+#include <windows.h>
+#include <io.h>       /* _get_osfhandle */
+#include <stddef.h>
+
+#define PROT_READ   1
+#define MAP_PRIVATE 2
+#define MAP_FAILED  ((void*)-1)
+
+static inline void *mmap(void *addr, size_t length, int prot, int flags,
+                         int fd, long long offset)
+{
+    (void)addr; (void)prot; (void)flags; (void)offset;
+
+    HANDLE fh = (HANDLE)_get_osfhandle(fd);
+    if(fh == INVALID_HANDLE_VALUE)
+        return MAP_FAILED;
+
+    HANDLE mapping = CreateFileMappingA(fh, NULL, PAGE_READONLY, 0, 0, NULL);
+    if(!mapping)
+        return MAP_FAILED;
+
+    void *ptr = MapViewOfFile(mapping, FILE_MAP_READ, 0, 0, length);
+    CloseHandle(mapping);   /* view keeps the mapping alive */
+    return ptr ? ptr : MAP_FAILED;
+}
+
+static inline int munmap(void *addr, size_t length)
+{
+    (void)length;
+    return UnmapViewOfFile(addr) ? 0 : -1;
+}
+
+#else /* POSIX */
+#include <sys/mman.h>
+#endif
+
+#endif /* MMAN_COMPAT_H */

--- a/src/mman_compat.h
+++ b/src/mman_compat.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 /**
  * Minimal mmap/munmap compatibility layer for Windows (MinGW).
  *
@@ -18,26 +20,31 @@
 #define MAP_PRIVATE 2
 #define MAP_FAILED  ((void*)-1)
 
-static inline void *mmap(void *addr, size_t length, int prot, int flags,
-                         int fd, long long offset)
-{
-    (void)addr; (void)prot; (void)flags; (void)offset;
+static inline void *mmap(void *addr, size_t length, int prot, int flags,  int fd, long long offset){
+    (void)addr;
+    (void)prot;
+    (void)flags;
+
+    if(offset != 0){
+        return MAP_FAILED;
+    }
 
     HANDLE fh = (HANDLE)_get_osfhandle(fd);
-    if(fh == INVALID_HANDLE_VALUE)
+    if(fh == INVALID_HANDLE_VALUE){
         return MAP_FAILED;
+    }
 
     HANDLE mapping = CreateFileMappingA(fh, NULL, PAGE_READONLY, 0, 0, NULL);
-    if(!mapping)
+    if(!mapping){
         return MAP_FAILED;
+    }
 
     void *ptr = MapViewOfFile(mapping, FILE_MAP_READ, 0, 0, length);
     CloseHandle(mapping);   /* view keeps the mapping alive */
     return ptr ? ptr : MAP_FAILED;
 }
 
-static inline int munmap(void *addr, size_t length)
-{
+static inline int munmap(void *addr, size_t length){
     (void)length;
     return UnmapViewOfFile(addr) ? 0 : -1;
 }

--- a/src/t2sz.c
+++ b/src/t2sz.c
@@ -19,9 +19,14 @@
 #include <string.h>
 #include <math.h>
 #include <fcntl.h>
-#include <unistd.h>
 #include <errno.h>
-#include <sys/mman.h>
+
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+#include "mman_compat.h"
 #include <zstd.h>
 
 typedef struct __attribute__((__packed__)) { /* byte offset */
@@ -1020,6 +1025,15 @@ static void cleanupCompression(Context *ctx){
  *             outFilename or stdoutMode, level, rawMode, block sizes, etc.).
  */
 void compressFile(Context *ctx){
+#ifdef _WIN32
+    if(ctx->stdinMode){
+        _setmode(_fileno(stdin), _O_BINARY);
+    }
+    if(ctx->stdoutMode){
+        _setmode(_fileno(stdout), _O_BINARY);
+    }
+#endif
+
     prepareOutput(ctx);
 
     prepareCctx(ctx);
@@ -1135,7 +1149,7 @@ void compressFile(Context *ctx){
             zstdResetFrame(ctx);
             zstdSetPledged(ctx, blockSize, true);
             if(ctx->verbose){
-                fprintf(stderr, "# END OF BLOCK (%lu, %lu)\n\n", blockSize, tarHeaderIdx);
+                fprintf(stderr, "# END OF BLOCK (%zu, %zu)\n\n", blockSize, tarHeaderIdx);
             }
 
             if(readBuff+blockSize > ctx->inBuff+ctx->inBuffSize){

--- a/src/t2sz.c
+++ b/src/t2sz.c
@@ -1027,10 +1027,16 @@ static void cleanupCompression(Context *ctx){
 void compressFile(Context *ctx){
 #ifdef _WIN32
     if(ctx->stdinMode){
-        _setmode(_fileno(stdin), _O_BINARY);
+        if(_setmode(_fileno(stdin), _O_BINARY) == -1){
+            fprintf(stderr, "t2sz: failed to set stdin to binary mode\n");
+            exit(EXIT_FAILURE);
+        }
     }
     if(ctx->stdoutMode){
-        _setmode(_fileno(stdout), _O_BINARY);
+        if(_setmode(_fileno(stdout), _O_BINARY) == -1){
+            fprintf(stderr, "t2sz: failed to set stdout to binary mode\n");
+            exit(EXIT_FAILURE);
+        }
     }
 #endif
 

--- a/tests/test_error_paths.sh
+++ b/tests/test_error_paths.sh
@@ -407,7 +407,7 @@ raw_nonmultiple_s)
     # Input size 1000001 bytes, -s 256k (262144). Not a multiple.
     # Expected frames: ceil(1000001 / 262144) = 4 (last frame is 213569 bytes).
     # Round-trip SHA-256 + seek table verification.
-    dd if=/dev/urandom of="$WORK/input.bin" bs=1 count=1000001 2>/dev/null
+    head -c 1000001 /dev/urandom > "$WORK/input.bin"
     sha_before=$(sha256_file "$WORK/input.bin")
     assert_exit 0  "$T2SZ" -r -s 256k -o "$WORK/out.zst" -f "$WORK/input.bin"
     zstd -d -f -q "$WORK/out.zst" -o "$WORK/dec.bin" || {
@@ -427,7 +427,7 @@ raw_nonmultiple_s)
 
 stdin_raw_nonmultiple_s)
     # Same as raw_nonmultiple_s but via stdin, exercising compressStdinRaw() Path B.
-    dd if=/dev/urandom of="$WORK/input.bin" bs=1 count=1000001 2>/dev/null
+    head -c 1000001 /dev/urandom > "$WORK/input.bin"
     sha_before=$(sha256_file "$WORK/input.bin")
     assert_exit 0  "$T2SZ" -r -s 256k -o "$WORK/out.zst" -f - < "$WORK/input.bin"
     zstd -d -f -q "$WORK/out.zst" -o "$WORK/dec.bin" || {

--- a/windows/win-cross-build.sh
+++ b/windows/win-cross-build.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# win-cross-build.sh — Cross-compile t2sz for Windows (Release, static).
+#
+# Produces stripped executables in build-windows-{arch}-release/.
+#
+# Usage:
+#   bash win-cross-build.sh [amd64|arm64|both]   (default: both)
+#
+# Environment variables (see win-cross-setup.sh for the full list):
+#   SRC_DIR          Source tree  (default: parent of script directory)
+#   BUILD_BASE_DIR   Build root   (default: SRC_DIR)
+#
+# Docker example:
+#   docker run --rm -v "$(pwd)":/src \
+#     ubuntu:24.04 bash /src/windows/win-cross-build.sh both
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${SCRIPT_DIR}/win-cross-setup.sh"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Build one architecture
+# ═══════════════════════════════════════════════════════════════════════════════
+build_one() {
+    local MINGW_TARGET="$1" ARCH="$2"
+    local BUILD_DIR="${BUILD_BASE_DIR}/build-windows-${ARCH}-release"
+    local ZSTD_PREFIX="/tmp/zstd-${MINGW_TARGET}"
+
+    echo ""
+    echo "====================================================="
+    echo "  Building for ${MINGW_TARGET}  (${ARCH})"
+    echo "====================================================="
+
+    # --- Build zstd as a static library (idempotent) ---
+    if [ ! -f "${ZSTD_PREFIX}/lib/libzstd.a" ]; then
+        cmake -S "${ZSTD_SRC_DIR}/build/cmake" -B "/tmp/build-zstd-${MINGW_TARGET}" \
+          -DCMAKE_SYSTEM_NAME=Windows \
+          -DCMAKE_C_COMPILER="${MINGW_TARGET}-gcc" \
+          -DCMAKE_RC_COMPILER="${MINGW_TARGET}-windres" \
+          -DCMAKE_INSTALL_PREFIX="${ZSTD_PREFIX}" \
+          -DZSTD_BUILD_PROGRAMS=OFF \
+          -DZSTD_BUILD_SHARED=OFF \
+          -DZSTD_BUILD_STATIC=ON \
+          -DCMAKE_BUILD_TYPE=Release
+        cmake --build "/tmp/build-zstd-${MINGW_TARGET}" -j"$(nproc)"
+        cmake --install "/tmp/build-zstd-${MINGW_TARGET}"
+    fi
+
+    # --- Build t2sz ---
+    cmake -S "${SRC_DIR}" -B "${BUILD_DIR}" \
+      -DCMAKE_SYSTEM_NAME=Windows \
+      -DCMAKE_C_COMPILER="${MINGW_TARGET}-gcc" \
+      -DCMAKE_RC_COMPILER="${MINGW_TARGET}-windres" \
+      -DCMAKE_FIND_ROOT_PATH="${ZSTD_PREFIX}" \
+      -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY \
+      -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_EXE_LINKER_FLAGS="-static"
+    cmake --build "${BUILD_DIR}" -j"$(nproc)"
+
+    # --- Strip ---
+    "${MINGW_TARGET}-strip" "${BUILD_DIR}/t2sz.exe"
+
+    echo ""
+    file "${BUILD_DIR}/t2sz.exe"
+    ls -lh "${BUILD_DIR}/t2sz.exe"
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Main — select architectures
+# ═══════════════════════════════════════════════════════════════════════════════
+ARCHES="${1:-both}"
+
+case "$ARCHES" in
+  amd64) build_one x86_64-w64-mingw32  amd64 ;;
+  arm64) build_one aarch64-w64-mingw32 arm64 ;;
+  both)
+    build_one x86_64-w64-mingw32  amd64
+    build_one aarch64-w64-mingw32 arm64
+    ;;
+  *) echo "Usage: $0 [amd64|arm64|both]"; exit 1 ;;
+esac
+
+echo ""
+echo "====================================================="
+echo "  Done!  Release executables:"
+echo "====================================================="
+ls -lh "${BUILD_BASE_DIR}"/build-windows-*-release/t2sz.exe 2>/dev/null || true

--- a/windows/win-cross-build.sh
+++ b/windows/win-cross-build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
 # win-cross-build.sh — Cross-compile t2sz for Windows (Release, static).
 #
 # Produces stripped executables in build-windows-{arch}-release/.

--- a/windows/win-cross-setup.sh
+++ b/windows/win-cross-setup.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
 # win-cross-setup.sh — Shared setup for Windows cross-compilation scripts.
 #
 # Installs llvm-mingw and downloads the zstd source tree.  All operations are
@@ -44,14 +45,21 @@ case "$HOST_ARCH" in
 esac
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# Install base build tools (idempotent)
+# Install base build tools (idempotent, independent of llvm-mingw)
+# ═══════════════════════════════════════════════════════════════════════════════
+if ! command -v cmake &>/dev/null; then
+    echo "Installing base tools (curl, cmake, make, xz-utils, file)..."
+    $SUDO apt-get update -qq
+    $SUDO apt-get install -y -qq curl cmake make xz-utils file > /dev/null 2>&1
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Install llvm-mingw cross-compiler (idempotent)
 # ═══════════════════════════════════════════════════════════════════════════════
 LLVM_MINGW_DIR="llvm-mingw-${LLVM_MINGW_VER}-ucrt-ubuntu-22.04-${LLVM_HOST}"
 
 if [ ! -d "/opt/${LLVM_MINGW_DIR}" ]; then
-    echo "Installing base tools and llvm-mingw ${LLVM_MINGW_VER} (${LLVM_HOST})..."
-    $SUDO apt-get update -qq
-    $SUDO apt-get install -y -qq curl cmake make xz-utils file > /dev/null 2>&1
+    echo "Installing llvm-mingw ${LLVM_MINGW_VER} (${LLVM_HOST})..."
     curl -fsSL \
       "https://github.com/mstorsjo/llvm-mingw/releases/download/${LLVM_MINGW_VER}/${LLVM_MINGW_DIR}.tar.xz" \
       | $SUDO tar -xJ -C /opt

--- a/windows/win-cross-setup.sh
+++ b/windows/win-cross-setup.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# win-cross-setup.sh — Shared setup for Windows cross-compilation scripts.
+#
+# Installs llvm-mingw and downloads the zstd source tree.  All operations are
+# idempotent: if the toolchain or source are already present they are reused.
+#
+# This file is meant to be **sourced** (not executed) by win-cross-build.sh
+# and win-cross-test.sh:
+#
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   . "${SCRIPT_DIR}/win-cross-setup.sh"
+#
+# Environment variables (all optional, with sensible defaults):
+#
+#   SRC_DIR          Path to the t2sz source tree       (default: SCRIPT_DIR/..)
+#   BUILD_BASE_DIR   Where build-windows-* dirs go      (default: SRC_DIR)
+#   ZSTD_VERSION     Zstd release to build against      (default: 1.5.7)
+#   LLVM_MINGW_VER   llvm-mingw release tag              (default: 20250417)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Defaults
+# ═══════════════════════════════════════════════════════════════════════════════
+: "${SRC_DIR:=$(cd "${SCRIPT_DIR}/.." && pwd)}"
+: "${BUILD_BASE_DIR:=${SRC_DIR}}"
+: "${ZSTD_VERSION:=1.5.7}"
+: "${LLVM_MINGW_VER:=20250417}"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# sudo detection — root inside Docker, non-root on CI runners
+# ═══════════════════════════════════════════════════════════════════════════════
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+    SUDO="sudo"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Detect host architecture
+# ═══════════════════════════════════════════════════════════════════════════════
+HOST_ARCH="$(uname -m)"
+case "$HOST_ARCH" in
+  aarch64|arm64) LLVM_HOST="aarch64" ;;
+  x86_64)        LLVM_HOST="x86_64"  ;;
+  *) echo "Unsupported host architecture: $HOST_ARCH"; exit 1 ;;
+esac
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Install base build tools (idempotent)
+# ═══════════════════════════════════════════════════════════════════════════════
+LLVM_MINGW_DIR="llvm-mingw-${LLVM_MINGW_VER}-ucrt-ubuntu-22.04-${LLVM_HOST}"
+
+if [ ! -d "/opt/${LLVM_MINGW_DIR}" ]; then
+    echo "Installing base tools and llvm-mingw ${LLVM_MINGW_VER} (${LLVM_HOST})..."
+    $SUDO apt-get update -qq
+    $SUDO apt-get install -y -qq curl cmake make xz-utils file > /dev/null 2>&1
+    curl -fsSL \
+      "https://github.com/mstorsjo/llvm-mingw/releases/download/${LLVM_MINGW_VER}/${LLVM_MINGW_DIR}.tar.xz" \
+      | $SUDO tar -xJ -C /opt
+else
+    echo "llvm-mingw ${LLVM_MINGW_VER} already installed."
+fi
+export PATH="/opt/${LLVM_MINGW_DIR}/bin:$PATH"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Download zstd source (idempotent)
+# ═══════════════════════════════════════════════════════════════════════════════
+ZSTD_SRC_DIR="/tmp/zstd-${ZSTD_VERSION}"
+
+if [ ! -d "$ZSTD_SRC_DIR" ]; then
+    echo "Downloading zstd ${ZSTD_VERSION} source..."
+    curl -fsSL \
+      "https://github.com/facebook/zstd/releases/download/v${ZSTD_VERSION}/zstd-${ZSTD_VERSION}.tar.gz" \
+      | tar -xz -C /tmp
+else
+    echo "zstd ${ZSTD_VERSION} source already present."
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Exports for consuming scripts
+# ═══════════════════════════════════════════════════════════════════════════════
+export SRC_DIR BUILD_BASE_DIR ZSTD_VERSION LLVM_MINGW_VER
+export SUDO LLVM_HOST ZSTD_SRC_DIR LLVM_MINGW_DIR

--- a/windows/win-cross-test.sh
+++ b/windows/win-cross-test.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# win-cross-test.sh — Cross-compile t2sz for Windows and run the full CTest
+# suite through Wine (Debug build with LLVM coverage).
+#
+# All 78 tests are driven by CTest (no manual listing here).  The trick is to
+# replace the built .exe files with shell-script wrappers that call Wine:
+# Linux does not care about extensions — it checks the shebang.
+#
+# The target architecture is auto-detected from the host.  On arm64 hosts Wine
+# is non-functional, so the script falls back to build-only mode.
+#
+# Usage:
+#   bash win-cross-test.sh
+#
+# Environment variables (see win-cross-setup.sh for the full list):
+#   SRC_DIR            Source tree     (default: parent of script directory)
+#   BUILD_BASE_DIR     Build root      (default: SRC_DIR)
+#   CTEST_JOBS         CTest parallelism (default: 4)
+#   CTEST_EXTRA_ARGS   Extra CTest flags (e.g. --exclude-regex raw_1gb)
+#
+# Docker example:
+#   docker run --rm --platform linux/amd64 -v "$(pwd)":/src \
+#     ubuntu:24.04 bash /src/windows/win-cross-test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "${SCRIPT_DIR}/win-cross-setup.sh"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Target architecture (derived from host)
+# ═══════════════════════════════════════════════════════════════════════════════
+case "$HOST_ARCH" in
+  aarch64|arm64) TARGET="aarch64-w64-mingw32"; ARCH="arm64" ;;
+  x86_64)        TARGET="x86_64-w64-mingw32";  ARCH="amd64" ;;
+esac
+
+BUILD_DIR="${BUILD_BASE_DIR}/build-windows-${ARCH}-debug"
+ZSTD_PREFIX="/tmp/zstd-${TARGET}"
+
+echo ""
+echo "====================================================="
+echo "  Windows cross-build + test (${ARCH})"
+echo "  Host: ${HOST_ARCH}  →  Target: ${TARGET}"
+echo "====================================================="
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Install test-specific tools: Wine + zstd CLI
+# ═══════════════════════════════════════════════════════════════════════════════
+$SUDO apt-get install -y -qq zstd > /dev/null 2>&1 || true
+
+WINE=""
+if $SUDO apt-get install -y -qq wine > /dev/null 2>&1; then
+    WINE="$(command -v wine64 2>/dev/null || command -v wine 2>/dev/null || true)"
+fi
+if [ -n "$WINE" ]; then
+    # Verify Wine can actually run a Windows command — on arm64 it installs but hangs
+    echo "Wine binary found: $WINE — verifying it can execute..."
+    if timeout 30 env WINEDEBUG=-all "$WINE" cmd /c echo ok >/dev/null 2>&1; then
+        echo "Wine: $WINE (verified working)"
+    else
+        echo "Wine: installed but non-functional (build-only mode)"
+        WINE=""
+    fi
+else
+    echo "Wine: not available (build-only mode)"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Build zstd as a static library (idempotent — reuses build from build script)
+# ═══════════════════════════════════════════════════════════════════════════════
+if [ ! -f "${ZSTD_PREFIX}/lib/libzstd.a" ]; then
+    echo ""
+    echo "====================================================="
+    echo "  Cross-compiling zstd (static, ${TARGET})"
+    echo "====================================================="
+    cmake -S "${ZSTD_SRC_DIR}/build/cmake" -B "/tmp/build-zstd-${TARGET}" \
+      -DCMAKE_SYSTEM_NAME=Windows \
+      -DCMAKE_C_COMPILER="${TARGET}-gcc" \
+      -DCMAKE_RC_COMPILER="${TARGET}-windres" \
+      -DCMAKE_INSTALL_PREFIX="${ZSTD_PREFIX}" \
+      -DZSTD_BUILD_PROGRAMS=OFF \
+      -DZSTD_BUILD_SHARED=OFF \
+      -DZSTD_BUILD_STATIC=ON \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build "/tmp/build-zstd-${TARGET}" -j"$(nproc)"
+    cmake --install "/tmp/build-zstd-${TARGET}"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Cross-compile t2sz + gen_blob (Debug, with tests + optional coverage)
+# ═══════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "====================================================="
+echo "  Cross-compiling t2sz + tests (${TARGET})"
+echo "====================================================="
+
+# Enable LLVM source-based coverage when Wine is available for testing
+COV_C_FLAGS=""
+COV_LINK_FLAGS=""
+if [ -n "$WINE" ]; then
+    COV_C_FLAGS="-fprofile-instr-generate -fcoverage-mapping"
+    COV_LINK_FLAGS="-fprofile-instr-generate"
+fi
+
+cmake -S "${SRC_DIR}" -B "$BUILD_DIR" \
+  -DCMAKE_SYSTEM_NAME=Windows \
+  -DCMAKE_C_COMPILER="${TARGET}-gcc" \
+  -DCMAKE_RC_COMPILER="${TARGET}-windres" \
+  -DCMAKE_FIND_ROOT_PATH="${ZSTD_PREFIX}" \
+  -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY \
+  -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DCMAKE_C_FLAGS="${COV_C_FLAGS}" \
+  -DCMAKE_EXE_LINKER_FLAGS="-static ${COV_LINK_FLAGS}" \
+  -DBUILD_TESTS=ON
+cmake --build "$BUILD_DIR" -j"$(nproc)"
+
+echo ""
+file "$BUILD_DIR/t2sz.exe"
+file "$BUILD_DIR/tests/gen_blob.exe"
+
+if [ -z "$WINE" ]; then
+    echo ""
+    echo "====================================================="
+    echo "  Build OK (${ARCH}) — Wine not available, skipping tests"
+    echo "====================================================="
+    exit 0
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Set up Wine wrappers for transparent CTest execution
+#
+# On Linux a file named "foo.exe" can be a shell script with a shebang.
+# We rename the real PE to .real.exe and place a wrapper at .exe, so CTest's
+# $<TARGET_FILE:t2sz> resolves to the wrapper which invokes Wine transparently.
+# ═══════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "====================================================="
+echo "  Setting up Wine wrappers for CTest"
+echo "====================================================="
+
+PROFDIR="${BUILD_DIR}/profraw"
+mkdir -p "$PROFDIR"
+
+# Initialize Wine prefix silently to avoid first-run noise
+timeout 60 env WINEDEBUG=-all $WINE cmd /c exit 2>/dev/null || true
+
+for exe in "$BUILD_DIR/t2sz.exe" "$BUILD_DIR/tests/gen_blob.exe"; do
+    real="${exe%.exe}.real.exe"
+    mv "$exe" "$real"
+    cat > "$exe" << WRAPPER
+#!/bin/bash
+WINEDEBUG=-all LLVM_PROFILE_FILE="${PROFDIR}/cov_%p_%m.profraw" exec $WINE "$real" "\$@"
+WRAPPER
+    chmod +x "$exe"
+done
+
+# Smoke test
+echo ""
+"$BUILD_DIR/t2sz.exe" -V || echo "(exit code: $?)"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Run the full CTest suite (all tests — same definitions as native build)
+# ═══════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "====================================================="
+echo "  CTest — full test suite (${ARCH} via Wine)"
+echo "====================================================="
+
+cd "$BUILD_DIR"
+CTEST_RC=0
+ctest --output-on-failure -j"${CTEST_JOBS:-4}" ${CTEST_EXTRA_ARGS:-} || CTEST_RC=$?
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Coverage report (LLVM source-based)
+# ═══════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "====================================================="
+echo "  Coverage Report (${ARCH})"
+echo "====================================================="
+
+if ls "$PROFDIR"/cov_*.profraw 1>/dev/null 2>&1; then
+    PROFDATA="${BUILD_DIR}/t2sz.profdata"
+    llvm-profdata merge -sparse "$PROFDIR"/cov_*.profraw -o "$PROFDATA"
+
+    llvm-cov report "${BUILD_DIR}/t2sz.real.exe" \
+        --instr-profile="$PROFDATA" \
+        --sources "${SRC_DIR}/src/"
+
+    # Save detailed annotated-source coverage
+    llvm-cov show "${BUILD_DIR}/t2sz.real.exe" \
+        --instr-profile="$PROFDATA" \
+        --sources "${SRC_DIR}/src/" \
+        --format=text > "${BUILD_DIR}/coverage-${ARCH}.txt" 2>/dev/null || true
+
+    echo ""
+    echo "Detailed coverage saved to ${BUILD_DIR}/coverage-${ARCH}.txt"
+else
+    echo "No profraw files found — coverage data unavailable"
+fi
+
+echo ""
+echo "====================================================="
+echo "  Done (${ARCH}): CTest exit code = ${CTEST_RC}"
+echo "====================================================="
+exit $CTEST_RC

--- a/windows/win-cross-test.sh
+++ b/windows/win-cross-test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
 # win-cross-test.sh — Cross-compile t2sz for Windows and run the full CTest
 # suite through Wine (Debug build with LLVM coverage).
 #
@@ -47,7 +48,11 @@ echo "====================================================="
 # ═══════════════════════════════════════════════════════════════════════════════
 # Install test-specific tools: Wine + zstd CLI
 # ═══════════════════════════════════════════════════════════════════════════════
-$SUDO apt-get install -y -qq zstd > /dev/null 2>&1 || true
+$SUDO apt-get install -y -qq zstd > /dev/null 2>&1
+if ! command -v zstd &>/dev/null; then
+    echo "ERROR: zstd CLI not available — cannot validate test outputs"
+    exit 1
+fi
 
 WINE=""
 if $SUDO apt-get install -y -qq wine > /dev/null 2>&1; then
@@ -148,6 +153,7 @@ timeout 60 env WINEDEBUG=-all $WINE cmd /c exit 2>/dev/null || true
 
 for exe in "$BUILD_DIR/t2sz.exe" "$BUILD_DIR/tests/gen_blob.exe"; do
     real="${exe%.exe}.real.exe"
+    [ -f "$real" ] && continue   # already wrapped from a previous run
     mv "$exe" "$real"
     cat > "$exe" << WRAPPER
 #!/bin/bash


### PR DESCRIPTION
This pull request introduces comprehensive support for building and testing Windows executables for `t2sz`, including cross-compilation workflows, CI integration, and Windows compatibility improvements. It also updates documentation to reflect these changes and bumps the project version to 1.2.3 across all packaging files. The most important changes are grouped below:

**Windows Support: Cross-compilation, Compatibility, and CI Integration**
- Added scripts for cross-compiling static Windows executables (`win-cross-build.sh`, `win-cross-setup.sh`) and for running the full test suite under Wine (`win-cross-test.sh`), enabling reproducible builds and automated testing for both amd64 and arm64 targets. [[1]](diffhunk://#diff-bf79e5ae4a59415e5cfde8bd7715bf6505f112861bff15d03e235d8561859e83R1-R89) [[2]](diffhunk://#diff-04ee77979d1f37e21daad0638586727a903098e6a02ac23e60c9eb373080cfb0R1-R81)
- Introduced a minimal mmap/munmap compatibility layer for Windows (`mman_compat.h`) and updated `t2sz.c` to use it, ensuring the codebase works on both POSIX and Windows platforms. Also added Windows-specific handling for binary mode on stdin/stdout and fixed format specifiers for cross-platform compatibility. [[1]](diffhunk://#diff-0ad0964e040f0dbd60964bb06fd884b1099b51c891b7734961ab019efff055d5R1-R49) [[2]](diffhunk://#diff-b17fb9758a9eb144acc8c7bcc67897033bc4ee8a6edefcd75cf1dd4b400826abL22-R29) [[3]](diffhunk://#diff-b17fb9758a9eb144acc8c7bcc67897033bc4ee8a6edefcd75cf1dd4b400826abR1028-R1036) [[4]](diffhunk://#diff-b17fb9758a9eb144acc8c7bcc67897033bc4ee8a6edefcd75cf1dd4b400826abL1138-R1152)
- Integrated Windows cross-compilation and Wine-based testing into GitHub Actions workflows (`deploy.yml`, `test.yml`), so Windows builds and tests are run automatically in CI. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R79-R98) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R66-R73)

**Documentation Updates**
- Expanded `README.md` and `TESTING.md` to document Linux, macOS, and Windows build instructions, including details on cross-compilation, Wine-based testing, and environment variables for the new scripts. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R37-R38) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R71-R103) [[3]](diffhunk://#diff-4da5f2fd7bc2f11672282410e99aad91d422f9f4fb6c723abc7ef29ee5cb6906R185-R255)

**Packaging and Version Bump**
- Bumped project version to 1.2.3 in all packaging and build files (`CMakeLists.txt`, `APKBUILD`, `PKGBUILD`, `snapcraft.yaml`) to reflect the new release. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL2-R2) [[2]](diffhunk://#diff-9d02a9f5b32ef57f03edeea2673bf874facd3f51789e70184f4488e4fe89541cL4-R4) [[3]](diffhunk://#diff-c13dbcca92f9ff12cd26ecce958be3f9ee8563baace04f7a463a6d2dd4252e0bL4-R4) [[4]](diffhunk://#diff-56759910381a014fecfd7556dd72ddd68c747d922a5b7df2044b9ce7c552f5f5L3-R3)
- Fixed a minor CMake install/strip issue for improved portability.

**Test Improvements**
- Updated test scripts to improve portability by replacing `dd` with `head` for generating random data, ensuring compatibility across more environments. [[1]](diffhunk://#diff-1b7580aa437d52356821ed556c0cf34b100f000e0028ae98892ad711379c33e4L410-R410) [[2]](diffhunk://#diff-1b7580aa437d52356821ed556c0cf34b100f000e0028ae98892ad711379c33e4L430-R430)