### PR TITLE
Improve input handling and version updates

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Marco Martinelli <marco+t2sz@13byte.com>
 # Maintainer: Marco Martinelli <marco+t2sz@13byte.com>
 pkgname=t2sz
-pkgver=1.2.3
+pkgver=1.2.4
 pkgrel=0
 pkgdesc="t2sz compresses a file into a seekable zstd with special handling for tar archives."
 url="https://github.com/martinellimarco/t2sz"

--- a/APKBUILD
+++ b/APKBUILD
@@ -1,7 +1,7 @@
 # Contributor: Marco Martinelli <marco+t2sz@13byte.com>
 # Maintainer: Marco Martinelli <marco+t2sz@13byte.com>
 pkgname=t2sz
-pkgver=1.2.4
+pkgver=1.2.5
 pkgrel=0
 pkgdesc="t2sz compresses a file into a seekable zstd with special handling for tar archives."
 url="https://github.com/martinellimarco/t2sz"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(t2sz VERSION 1.2.3 LANGUAGES C)
+project(t2sz VERSION 1.2.4 LANGUAGES C)
 
 add_definitions(-DVERSION="${PROJECT_VERSION}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(t2sz VERSION 1.2.4 LANGUAGES C)
+project(t2sz VERSION 1.2.5 LANGUAGES C)
 
 add_definitions(-DVERSION="${PROJECT_VERSION}")
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 #Maintainer: Marco Martinelli <marco+t2sz@13byte.com>
 
 pkgname=t2sz
-pkgver=1.2.4
+pkgver=1.2.5
 pkgrel=1
 pkgdesc="It compresses a file into a seekable zstd. If the file is a tar archive it compresses each file in the archive into an independent frame, hence the name: tar 2 seekable zstd."
 arch=('i686' 'x86_64' 'armv7h' 'aarch64')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 #Maintainer: Marco Martinelli <marco+t2sz@13byte.com>
 
 pkgname=t2sz
-pkgver=1.2.3
+pkgver=1.2.4
 pkgrel=1
 pkgdesc="It compresses a file into a seekable zstd. If the file is a tar archive it compresses each file in the archive into an independent frame, hence the name: tar 2 seekable zstd."
 arch=('i686' 'x86_64' 'armv7h' 'aarch64')

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: t2sz
 base: core24
-version: '1.2.4'
+version: '1.2.5'
 summary: It compresses a file into a seekable .zstd file
 description: |
   It compresses a file into a seekable zstd splitting the file into multiple frames.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: t2sz
 base: core24
-version: '1.2.3'
+version: '1.2.4'
 summary: It compresses a file into a seekable .zstd file
 description: |
   It compresses a file into a seekable zstd splitting the file into multiple frames.

--- a/src/t2sz.c
+++ b/src/t2sz.c
@@ -158,15 +158,21 @@ typedef struct {
     bool skipSeekTable;
 } Context;
 
-/**
- * Detect the host byte order at runtime.
- *
- * @return  true on little-endian machines (x86, ARM64), false on big-endian.
- */
-bool isLittleEndian(){
-    volatile int x = 1;
-    return *(char*)(&x) == 1;
+/* Compile-time endianness detection.  GCC/Clang define __BYTE_ORDER__
+ * and __ORDER_LITTLE_ENDIAN__; MSVC is always little-endian on supported
+ * architectures.  If none of the macros are available the runtime
+ * fallback is used (no volatile — the result is constant). */
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__)
+#define IS_LITTLE_ENDIAN (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#elif defined(_WIN32)
+#define IS_LITTLE_ENDIAN 1
+#else
+static inline bool isLittleEndian(void){
+    const int x = 1;
+    return *(const char*)(&x) == 1;
 }
+#define IS_LITTLE_ENDIAN isLittleEndian()
+#endif
 
 /**
  * Write a 32-bit unsigned integer to memory in little-endian byte order.
@@ -178,7 +184,7 @@ bool isLittleEndian(){
  * @param data  The value to store.
  */
 void writeLE32(void* dst, const uint32_t data){
-    if(isLittleEndian()){
+    if(IS_LITTLE_ENDIAN){
         memcpy(dst, &data, sizeof(data));
     }else{
         const uint32_t swap = ((data & 0xFF000000) >> 24) |

--- a/src/t2sz.c
+++ b/src/t2sz.c
@@ -371,8 +371,12 @@ Context* newContext(){
  * into ctx->inBuff. Aborts on any I/O error or if the file is empty.
  * No-op when ctx->stdinMode is true (stdin is handled separately).
  *
+ * If the input is not seekable (pipe, FIFO, or process substitution such
+ * as bash's <(...)), redirects the fd to stdin via dup2() and sets
+ * ctx->stdinMode = true so the caller falls through to the streaming path.
+ *
  * @param ctx  The compression context (reads inFilename, stdinMode;
- *             writes inBuff, inBuffSize).
+ *             writes inBuff, inBuffSize, stdinMode).
  */
 void prepareInput(Context *ctx){
     if(ctx->stdinMode){
@@ -394,9 +398,19 @@ void prepareInput(Context *ctx){
 
     const off_t end = lseek(fd, 0, SEEK_END);
     if(end < 0){
-        fprintf(stderr, "ERROR: Unable to seek '%s'\n", ctx->inFilename);
-        close(fd);
-        exit(EXIT_FAILURE);
+        // Non-seekable input (pipe, FIFO, or process substitution).
+        // Redirect to stdin so the streaming code path can handle it.
+        if(fd != STDIN_FILENO){
+            if(dup2(fd, STDIN_FILENO) < 0){
+                fprintf(stderr, "ERROR: Unable to redirect '%s' to stdin\n",
+                        ctx->inFilename);
+                close(fd);
+                exit(EXIT_FAILURE);
+            }
+            close(fd);
+        }
+        ctx->stdinMode = true;
+        return;
     }
     if(end == 0){
         fprintf(stderr, "ERROR: Empty input file '%s'\n", ctx->inFilename);
@@ -1031,6 +1045,12 @@ static void cleanupCompression(Context *ctx){
  *             outFilename or stdoutMode, level, rawMode, block sizes, etc.).
  */
 void compressFile(Context *ctx){
+    // For file inputs, prepareInput() may detect a non-seekable source
+    // (pipe, FIFO, process substitution) and switch to stdinMode.
+    if(!ctx->stdinMode){
+        prepareInput(ctx);
+    }
+
 #ifdef _WIN32
     if(ctx->stdinMode){
         if(_setmode(_fileno(stdin), _O_BINARY) == -1){
@@ -1059,7 +1079,6 @@ void compressFile(Context *ctx){
 
         cleanupCompression(ctx);
     }else{
-        prepareInput(ctx);
 
         size_t tarHeaderIdx = 0;
         uint8_t* readBuff = ctx->inBuff;

--- a/tests/test_coverage.sh
+++ b/tests/test_coverage.sh
@@ -25,19 +25,44 @@ PROFDATA="$BUILD_DIR/coverage.profdata"
 HTML_DIR="$SCRIPT_DIR/coverage/html"
 
 # ── Locate llvm-profdata and llvm-cov ────────────────────────────────────────
+# Search order:
+#   1. Homebrew LLVM — /opt/homebrew/opt/llvm/bin (unversioned)
+#   2. Homebrew LLVM — /opt/homebrew/opt/llvm@*/bin (versioned, highest first)
+#   3. Xcode toolchain (via xcrun) — ships with Xcode Command Line Tools
+#   4. System PATH
 OS="$(uname -s)"
 
 find_tool() {
     local name="$1"
-    local homebrew_path="/opt/homebrew/opt/llvm/bin/$name"
-    if [ "$OS" = "Darwin" ] && [ -x "$homebrew_path" ]; then
-        echo "$homebrew_path"
-    elif command -v "$name" >/dev/null 2>&1; then
-        echo "$name"
-    else
-        printf "Error: '%s' not found. On macOS: brew install llvm\n" "$name" >&2
-        exit 1
+    # 1) Homebrew unversioned
+    local brew_path="/opt/homebrew/opt/llvm/bin/$name"
+    if [ -x "$brew_path" ]; then
+        echo "$brew_path"
+        return
     fi
+    # 2) Homebrew versioned (llvm@18, llvm@19, llvm@21, …) — pick highest
+    local versioned
+    versioned="$(ls -d /opt/homebrew/opt/llvm@*/bin/"$name" 2>/dev/null | sort -t@ -k2 -rn | head -1)" || true
+    if [ -n "$versioned" ] && [ -x "$versioned" ]; then
+        echo "$versioned"
+        return
+    fi
+    # 3) Xcode toolchain
+    if [ "$OS" = "Darwin" ] && command -v xcrun >/dev/null 2>&1; then
+        local xc_path
+        xc_path="$(xcrun -f "$name" 2>/dev/null)" || true
+        if [ -n "$xc_path" ] && [ -x "$xc_path" ]; then
+            echo "$xc_path"
+            return
+        fi
+    fi
+    # 4) System PATH
+    if command -v "$name" >/dev/null 2>&1; then
+        echo "$name"
+        return
+    fi
+    printf "Error: '%s' not found. On macOS: brew install llvm\n" "$name" >&2
+    exit 1
 }
 
 LLVM_PROFDATA="$(find_tool llvm-profdata)"


### PR DESCRIPTION
This pull request updates the `t2sz` project to version 1.2.5 and introduces improvements to input handling and portability, especially for non-seekable input sources. It also enhances the coverage test script for better tool detection on macOS. The most important changes are:

**Version Updates:**

* Bumped the project version from 1.2.3 to 1.2.5 in `APKBUILD`, `PKGBUILD`, `CMakeLists.txt`, and `snap/snapcraft.yaml` to reflect the new release. [[1]](diffhunk://#diff-9d02a9f5b32ef57f03edeea2673bf874facd3f51789e70184f4488e4fe89541cL4-R4) [[2]](diffhunk://#diff-c13dbcca92f9ff12cd26ecce958be3f9ee8563baace04f7a463a6d2dd4252e0bL4-R4) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL2-R2) [[4]](diffhunk://#diff-56759910381a014fecfd7556dd72ddd68c747d922a5b7df2044b9ce7c552f5f5L3-R3)

**Input Handling Improvements:**

* Enhanced `prepareInput` in `src/t2sz.c` to detect non-seekable inputs (like pipes, FIFOs, or process substitutions), redirect them to stdin, and set `stdinMode` for proper streaming. This improves robustness when handling various input sources. [[1]](diffhunk://#diff-b17fb9758a9eb144acc8c7bcc67897033bc4ee8a6edefcd75cf1dd4b400826abR374-R379) [[2]](diffhunk://#diff-b17fb9758a9eb144acc8c7bcc67897033bc4ee8a6edefcd75cf1dd4b400826abL391-R414) [[3]](diffhunk://#diff-b17fb9758a9eb144acc8c7bcc67897033bc4ee8a6edefcd75cf1dd4b400826abR1048-R1053) [[4]](diffhunk://#diff-b17fb9758a9eb144acc8c7bcc67897033bc4ee8a6edefcd75cf1dd4b400826abL1056)

**Portability and Endianness Detection:**

* Replaced the runtime endianness check with a compile-time check using preprocessor macros for GCC/Clang and MSVC, with a fallback to a simplified runtime check. Updated usage accordingly in `src/t2sz.c`. [[1]](diffhunk://#diff-b17fb9758a9eb144acc8c7bcc67897033bc4ee8a6edefcd75cf1dd4b400826abL161-R175) [[2]](diffhunk://#diff-b17fb9758a9eb144acc8c7bcc67897033bc4ee8a6edefcd75cf1dd4b400826abL181-R187)

**Test Coverage Script Improvements:**

* Improved the `find_tool` function in `tests/test_coverage.sh` to search for LLVM tools in a prioritized order on macOS: Homebrew (unversioned and versioned), Xcode toolchain, then system PATH, providing better reliability across environments.